### PR TITLE
Bugfix/omt 200 claim status not updated

### DIFF
--- a/claim_batch/services.py
+++ b/claim_batch/services.py
@@ -90,26 +90,26 @@ def relative_index_calculation_monthly(rel_type, period, year, location_id, prod
     else:
         raise Exception("relative type should be month(12), quarter(4) or year(1)")
 
-    for month in range(month_start, month_end + 1):
-        with transaction.atomic():
-            date = datetime.date(year, period, 1)
-            # We don't import the localized calendar because this process is currently based on gregorian calendar
-            _, days_in_month = calendar.monthrange(year, period)
-            end_date = datetime.date(year, period, days_in_month)
+    with transaction.atomic():
+        date = datetime.date(year, period, 1)
+        # We don't import the localized calendar because this process is currently based on gregorian calendar
+        _, days_in_month = calendar.monthrange(year, period)
+        end_date = datetime.date(year, period, days_in_month)
 
-            # For some reason the temp table is not always deleted when we arrive here, so we generate a random name
-            table_name = "#Numerator" + uuid.uuid4().hex
-            cursor = connection.cursor()
-            cursor.execute(f"""
-            CREATE TABLE {table_name}
-            (
-                LocationId int,
-                ProdID     int,
-                Value      decimal(18, 2),
-                WorkValue  int
-            )
-            """)
+        # For some reason the temp table is not always deleted when we arrive here, so we generate a random name
+        table_name = "#Numerator" + uuid.uuid4().hex
+        cursor = connection.cursor()
+        cursor.execute(f"""
+        CREATE TABLE {table_name}
+        (
+            LocationId int,
+            ProdID     int,
+            Value      decimal(18, 2),
+            WorkValue  int
+        )
+        """)
 
+        for month in range(month_start, month_end + 1):
             # insert into numerator (location_id, product_id, value, work_value)
             # The Django approach to that query doesn't work in Django 2 as it needs a boolean condition on the F in When
             # Policy.objects\
@@ -230,52 +230,57 @@ def relative_index_calculation_monthly(rel_type, period, year, location_id, prod
                            AND (Prod.ProdID=%s or %s=0)
                            AND PL.PolicyStatus <> 1
                            AND PR.PayDate <= PL.ExpiryDate
-
+    
                          GROUP BY L.LocationId, Prod.ProdID, PR.Amount, PR.PayDate, PL.ExpiryDate, PL.EffectiveDate
                      ) NumValue
                 GROUP BY LocationId, ProdID
             """
             cursor.execute(sql, params)
 
-            cursor.execute(f"""
-                INSERT INTO {table_name} (LocationId, ProdID, Value, WorkValue)
-                SELECT LocationId, ProdID, ISNULL(SUM(Value), 0) Allocated, 0
-                FROM {table_name}
-                GROUP BY LocationId, ProdID
-            """)
-            cursor.execute(f"""
-                DELETE FROM {table_name} WHERE WorkValue = 1
-            """)
+        # The above query was run for each month in range with WorkValue=1. We group the data with WorkValue=0
+        # and then delete the =1 data.
+        cursor.execute(f"""
+            INSERT INTO {table_name} (LocationId, ProdID, Value, WorkValue)
+            SELECT LocationId, ProdID, ISNULL(SUM(Value), 0) Allocated, 0
+            FROM {table_name}
+            GROUP BY LocationId, ProdID
+        """)
+        cursor.execute(f"""
+            DELETE FROM {table_name} WHERE WorkValue = 1
+        """)
 
-            cursor.execute(f"SELECT ProdID, Value FROM {table_name}")
-            rel_price_mapping = [
-                ("period_rel_prices", "B"),
-                ("period_rel_prices_ip", "I"),
-                ("period_rel_prices_op", "O")
-            ]
-            for prod_id, prod_value in cursor.fetchall():
-                product = Product.objects.filter(id=prod_id).first()
-                if rel_type == RelativeIndex.TYPE_MONTH:
-                    for rel_price_item, rel_price_type in rel_price_mapping:
-                        if product and getattr(product, rel_price_item) == Product.RELATIVE_PRICE_PERIOD_MONTH:
-                            create_relative_index(prod_id, prod_value, year, rel_type, location_id, audit_user_id,
-                                                  rel_price_type, period=period)
+        cursor.execute(f"SELECT ProdID, Value FROM {table_name}")
+        rel_price_mapping = [
+            ("period_rel_prices", "B"),
+            ("period_rel_prices_ip", "I"),
+            ("period_rel_prices_op", "O")
+        ]
+        for prod_id, prod_value in cursor.fetchall():
+            product = Product.objects.filter(id=prod_id).first()
+            if rel_type == RelativeIndex.TYPE_MONTH:
+                for rel_price_item, rel_price_type in rel_price_mapping:
+                    if product and getattr(product, rel_price_item) == Product.RELATIVE_PRICE_PERIOD_MONTH:
+                        create_relative_index(prod_id, prod_value, year, rel_type, location_id, audit_user_id,
+                                              rel_price_type, period=period)
 
-                if rel_type == RelativeIndex.TYPE_QUARTER:
-                    for rel_price_item, rel_price_type in rel_price_mapping:
-                        if product and getattr(product, rel_price_item) == Product.RELATIVE_PRICE_PERIOD_QUARTER:
-                            create_relative_index(prod_id, prod_value, year, rel_type, location_id, audit_user_id,
-                                                  rel_price_type, month_start=month_start, month_end=month_end)
+            if rel_type == RelativeIndex.TYPE_QUARTER:
+                for rel_price_item, rel_price_type in rel_price_mapping:
+                    if product and getattr(product, rel_price_item) == Product.RELATIVE_PRICE_PERIOD_QUARTER:
+                        create_relative_index(prod_id, prod_value, year, rel_type, location_id, audit_user_id,
+                                              rel_price_type, month_start=month_start, month_end=month_end)
 
-                if rel_type == RelativeIndex.TYPE_YEAR:
-                    for rel_price_item, rel_price_type in rel_price_mapping:
-                        if product and getattr(product, rel_price_item) == Product.RELATIVE_PRICE_PERIOD_YEAR:
-                            create_relative_index(prod_id, prod_value, year, rel_type, location_id, audit_user_id,
-                                                  rel_price_type)
+            if rel_type == RelativeIndex.TYPE_YEAR:
+                for rel_price_item, rel_price_type in rel_price_mapping:
+                    if product and getattr(product, rel_price_item) == Product.RELATIVE_PRICE_PERIOD_YEAR:
+                        create_relative_index(prod_id, prod_value, year, rel_type, location_id, audit_user_id,
+                                              rel_price_type)
 
 
 def create_relative_index(prod_id, prod_value, year, relative_type, location_id, audit_user_id, rel_price_type,
                           period=None, month_start=None, month_end=None):
+    logger.debug ("Creating relative index for product %s with value %s on year %s, type %s, location %s, "
+                 "rel_price_type %s, period %s, month range %s-%s", prod_id, prod_value, year, relative_type,
+                 location_id, rel_price_type, period, month_start, month_end)
     distr = RelativeDistribution.objects \
         .filter(product_id=prod_id) \
         .filter(period=period) \
@@ -321,7 +326,7 @@ def create_relative_index(prod_id, prod_value, year, relative_type, location_id,
     return RelativeIndex.objects.create(
         product_id=prod_id,
         type=relative_type,
-        care_type=RelativeIndex.CARE_TYPE_IN_PATIENT,
+        care_type=rel_price_type,
         year=year,
         period=period,
         calc_date=TimeUtils.now(),
@@ -361,24 +366,33 @@ def process_batch(audit_user_id, location_id, period, year):
 
 
 def do_process_batch(audit_user_id, location_id, period, year):
+    processed_ids = set()  # As we update claims, we add the claims not in relative pricing and then update the status
+    logger.debug("do_process_batch location %s for %s/%s", location_id, period, year)
     relative_index_calculation_monthly(rel_type=12, period=period, year=year, location_id=location_id, product_id=0,
                                        audit_user_id=audit_user_id)
     if period == 3:
+        logger.debug("do_process_batch generating Q1")
         relative_index_calculation_monthly(rel_type=4, period=1, year=year, location_id=location_id, product_id=0,
                                            audit_user_id=audit_user_id)
     if period == 6:
+        logger.debug("do_process_batch generating Q2")
         relative_index_calculation_monthly(rel_type=4, period=2, year=year, location_id=location_id, product_id=0,
                                            audit_user_id=audit_user_id)
     if period == 9:
+        logger.debug("do_process_batch generating Q2")
         relative_index_calculation_monthly(rel_type=4, period=3, year=year, location_id=location_id, product_id=0,
                                            audit_user_id=audit_user_id)
     if period == 12:
+        logger.debug("do_process_batch generating Q4 and Year")
         relative_index_calculation_monthly(rel_type=4, period=4, year=year, location_id=location_id, product_id=0,
                                            audit_user_id=audit_user_id)
         relative_index_calculation_monthly(rel_type=1, period=1, year=year, location_id=location_id, product_id=0,
                                            audit_user_id=audit_user_id)
 
+
     for svc_item in [ClaimItem, ClaimService]:
+        logger.debug("do_process_batch Checking %s",
+                        "ClaimItem" if isinstance(svc_item, ClaimItem) else "ClaimService")
         prod_qs = svc_item.objects \
             .filter(claim__status=Claim.STATUS_PROCESSED) \
             .filter(claim__validity_to__isnull=True) \
@@ -393,7 +407,7 @@ def do_process_batch(audit_user_id, location_id, period, year):
             "product__period_rel_prices_op",
             "product__period_rel_prices_ip", "claim__process_stamp__month", "claim__process_stamp__year") \
             .distinct()
-
+        logger.debug("do_process_batch queried")
         for product in product_loop:
             index = -1
             target_month = product["claim__process_stamp__month"]
@@ -401,31 +415,44 @@ def do_process_batch(audit_user_id, location_id, period, year):
             # Will fail with Ethiopian calendar but so will the rest of this procedure
             target_quarter = int((target_month - 1) / 3) + 1
 
+            logger.debug("do_process_batch target %s/%s Q%s", target_month, target_year, target_quarter)
             if product["product__period_rel_prices"]:
+                logger.debug("do_process_batch period_rel_prices %s", product["product__period_rel_prices"])
                 prod_rel_price_type = product["product__period_rel_prices"]
             elif product["claim__health_facility__level"] == 'H' and product["product__period_rel_prices_ip"]:
+                logger.debug("do_process_batch product__period_rel_prices_ip %s", product["product__period_rel_prices_ip"])
                 prod_rel_price_type = product["product__period_rel_prices_ip"]
             elif product["claim__health_facility__level"] != 'H' and product["product__period_rel_prices_op"]:
+                logger.debug("do_process_batch product__period_rel_prices_op %s", product["product__period_rel_prices_op"])
                 prod_rel_price_type = product["product__period_rel_prices_op"]
             else:
+                logger.error(f"product {product['product_id']} has an impossible in/out patient or both")
                 raise Exception(f"product {product['product_id']} has an impossible in/out patient or both")
 
-            if prod_rel_price_type == RelativeIndex.TYPE_MONTH:
+            if prod_rel_price_type == Product.RELATIVE_PRICE_PERIOD_MONTH:
+                logger.debug("do_process_batch Month")
                 index = _get_relative_index(product["product_id"], target_month, target_year,
                                             RelativeIndex.CARE_TYPE_BOTH,
                                             RelativeIndex.TYPE_MONTH)
-            if prod_rel_price_type == RelativeIndex.TYPE_QUARTER:
+            if prod_rel_price_type == Product.RELATIVE_PRICE_PERIOD_QUARTER:
+                logger.debug("do_process_batch Quarter")
                 index = _get_relative_index(product["product_id"], target_quarter, target_year,
                                             RelativeIndex.CARE_TYPE_BOTH, RelativeIndex.TYPE_QUARTER)
-            if prod_rel_price_type == RelativeIndex.TYPE_YEAR:
+            if prod_rel_price_type == Product.RELATIVE_PRICE_PERIOD_YEAR:
+                logger.debug("do_process_batch Year")
                 index = _get_relative_index(product["product_id"], None, target_year, RelativeIndex.CARE_TYPE_BOTH,
                                             RelativeIndex.TYPE_YEAR)
+            if prod_rel_price_type not in (Product.RELATIVE_PRICE_PERIOD_MONTH, Product.RELATIVE_PRICE_PERIOD_QUARTER,
+                                           Product.RELATIVE_PRICE_PERIOD_YEAR):
+                logger.error("do_process_batch invalid value for prod_rel_price_type %s", prod_rel_price_type)
 
             if index > -1:
-                prod_qs \
+                to_update_qs = prod_qs \
                     .filter(claim__health_facility__level=product["claim__health_facility__level"]) \
-                    .filter(product_id=product["product_id"]) \
-                    .update(remunerated_amount=F(F("price_valuated") * index))
+                    .filter(product_id=product["product_id"])
+                processed_ids.update(to_update_qs.values_list("claim_id", flat=True).distinct())
+                updated_count = to_update_qs.update(remunerated_amount=F("price_valuated") * index)
+                logger.debug("do_process_batch updated remunerated_amount count %s", updated_count)
 
     # Get all the claims in valuated state with no Relative index /Services
     def filter_valuated_claims(base):
@@ -444,8 +471,9 @@ def do_process_batch(audit_user_id, location_id, period, year):
 
     item_ids = filter_valuated_claims(ClaimItem)
     service_ids = filter_valuated_claims(ClaimService)
+    logger.debug("do_process_batch item/service counts: %s/%s", item_ids.count(), service_ids.count())  # TODO remove to reduce queries
 
-    all_ids = item_ids.union(service_ids).distinct().values_list("id", flat=True)
+    processed_ids.update(item_ids.union(service_ids).distinct().values_list("id", flat=True))
 
     def filter_item_or_service(base):
         return base.objects \
@@ -462,19 +490,20 @@ def do_process_batch(audit_user_id, location_id, period, year):
     item_prod_ids = filter_item_or_service(ClaimItem)
     service_prod_ids = filter_item_or_service(ClaimService)
 
-    Claim.objects \
+    updated_count = Claim.objects \
         .filter(status=Claim.STATUS_PROCESSED) \
-        .filter(id__in=all_ids) \
+        .filter(id__in=processed_ids) \
         .filter(validity_to__isnull=True) \
         .exclude(id__in=item_prod_ids) \
         .exclude(id__in=service_prod_ids) \
         .update(status=Claim.STATUS_VALUATED)
+    logger.debug("do_process_batch update claims: %s", updated_count)
 
     from core.utils import TimeUtils
     created_run = BatchRun.objects.create(location_id=location_id, run_year=year, run_month=period,
                                           run_date=TimeUtils.now(), audit_user_id=audit_user_id,
                                           validity_from=TimeUtils.now())
-
+    logger.debug("do_process_batch created run: %s", created_run.id)
     month_start = 0
     month_end = 0
     if period in (3, 6, 9):
@@ -486,21 +515,24 @@ def do_process_batch(audit_user_id, location_id, period, year):
 
     # Link claims to this batch run
     filter_base = Claim.objects \
-        .filter(id__in=all_ids) \
+        .filter(id__in=processed_ids) \
         .filter(status=Claim.STATUS_VALUATED) \
         .filter(batch_run_id__isnull=True) \
         .filter(process_stamp__year=year)
 
-    filter_base \
+    updated_count = filter_base \
         .filter(process_stamp__month=period) \
         .update(batch_run=created_run)
 
+    logger.debug("do_process_batch updated claims with batch run ref %s", updated_count)
+
     # If more than a month was run
     if month_start > 0:
-        filter_base \
+        updated_count = filter_base \
             .filter(process_stamp__month__gte=month_start) \
             .filter(process_stamp__month__lte=month_end) \
             .update(batch_run=created_run)
+        logger.debug("do_process_batch updated claims *range* with batch run ref %s", updated_count)
 
 
 def _get_relative_index(product_id, relative_period, relative_year, relative_care_type='B', relative_type=12):
@@ -730,7 +762,7 @@ class ReportDataService(object):
         else:
             data = process_batch_report_data(prms)
         if not data:
-            raise ValueError(_("claim_batch.reports.nodata"))
+            raise ValueError(_("claim_batch.reports.nodata.TEST"))
         df = pd.DataFrame.from_dict(data)
         if group == "H":
             return add_sums_by_hf(data,

--- a/claim_batch/tests.py
+++ b/claim_batch/tests.py
@@ -1,70 +1,130 @@
-from claim.models import Claim
-from claim.test_helpers import create_test_claim, create_test_claimservice
-from claim.validations import validate_claim, validate_assign_prod_to_claimitems_and_services
+from claim.gql_mutations import validate_and_process_dedrem_claim
+from claim.models import ClaimDedRem, Claim
+from claim.test_helpers import (
+    create_test_claim,
+    create_test_claimservice,
+    create_test_claimitem,
+    delete_claim_with_itemsvc_dedrem_and_history,
+)
 from claim_batch.models import RelativeDistribution
-from claim_batch.services import process_batch
+from claim_batch.services import do_process_batch
 from claim_batch.test_helpers import create_test_rel_distr_range
-from contribution.test_helpers import create_test_premium
+from contribution.test_helpers import create_test_payer, create_test_premium
+from core.models import User, InteractiveUser
 from django.test import TestCase
 from insuree.test_helpers import create_test_insuree
-from medical.test_helpers import create_test_service
-from medical_pricelist.test_helpers import add_service_to_hf_pricelist
+from medical.test_helpers import create_test_service, create_test_item
+from medical_pricelist.test_helpers import (
+    add_service_to_hf_pricelist,
+    add_item_to_hf_pricelist,
+)
 from policy.test_helpers import create_test_policy
-from product.models import ProductService
-from product.test_helpers import create_test_product, create_test_product_service
+from product.models import ProductItemOrService, Product
+from product.test_helpers import (
+    create_test_product,
+    create_test_product_service,
+    create_test_product_item,
+)
 
 
-def _mark_as_processed(claim):
-    claim.status = Claim.STATUS_PROCESSED
-    claim.audit_user_id_process = -1
-    claim.process_stamp = claim.date_claimed
-    claim.save()
-
-
-class BatchRunTests(TestCase):
+class BatchRunTest(TestCase):
     def setUp(self) -> None:
-        pass
+        self.i_user = InteractiveUser(
+            login_name="test_batch_run", audit_user_id=-1, id=97891
+        )
+        self.user = User(i_user=self.i_user)
 
-    def tearDown(self) -> None:
-        pass
+    def test_simple_batch(self):
+        """
+        This test creates a claim, submits it so that it gets dedrem entries,
+        then submits a review rejecting part of it, then process the claim.
+        It should not be processed (which was ok) but the dedrem should be deleted.
+        """
+        # Given
+        insuree = create_test_insuree()
+        self.assertIsNotNone(insuree)
+        service = create_test_service("A", custom_props={"name": "test_simple_batch"})
+        item = create_test_item("A", custom_props={"name": "test_simple_batch"})
 
-    def test_simple_monthly_batch_run(self) -> None:
-        insuree1 = create_test_insuree()
-        self.assertIsNotNone(insuree1)
-        product = create_test_product("TEST1", custom_props={"location_id": 1, "period_rel_prices": 4})
-        policy = create_test_policy(product, insuree1, link=True)
-        service = create_test_service("V")
-        product_service = create_test_product_service(product, service,
-                                                      custom_props={"price_origin": ProductService.ORIGIN_RELATIVE})
-        pricelist_detail = add_service_to_hf_pricelist(service)
-        premium = create_test_premium(policy_id=policy.id, with_payer=True)
-        create_test_rel_distr_range(product.id, RelativeDistribution.TYPE_QUARTER,
-                                    RelativeDistribution.CARE_TYPE_BOTH, 10)
+        product = create_test_product(
+            "BCUL0001",
+            custom_props={
+                "name": "simplebatch",
+                "lump_sum": 10_000,
+                "period_rel_prices": Product.RELATIVE_PRICE_PERIOD_MONTH,
+            },
+        )
+        create_test_rel_distr_range(
+            product.id,
+            RelativeDistribution.TYPE_MONTH,
+            RelativeDistribution.CARE_TYPE_BOTH,
+            10,
+        )
+        product_service = create_test_product_service(
+            product,
+            service,
+            custom_props={"price_origin": ProductItemOrService.ORIGIN_RELATIVE},
+        )
+        product_item = create_test_product_item(
+            product,
+            item,
+            custom_props={"price_origin": ProductItemOrService.ORIGIN_RELATIVE},
+        )
+        policy = create_test_policy(product, insuree, link=True)
+        payer = create_test_payer()
+        premium = create_test_premium(
+            policy_id=policy.id, custom_props={"payer_id": payer.id}
+        )
+        pricelist_detail1 = add_service_to_hf_pricelist(service)
+        pricelist_detail2 = add_item_to_hf_pricelist(item)
 
-        claim1 = create_test_claim({"insuree_id": insuree1.id})
-        service1 = create_test_claimservice(claim1, custom_props={"service_id": service.id,
-                                                                  "price_origin": ProductService.ORIGIN_RELATIVE,
-                                                                  "product": product})
-        errors = validate_claim(claim1, True)
-        self.assertEquals(len(errors), 0)
-        errors = validate_assign_prod_to_claimitems_and_services(claim1)
-        self.assertEquals(len(errors), 0)
-        _mark_as_processed(claim1)
+        claim1 = create_test_claim({"insuree_id": insuree.id})
+        service1 = create_test_claimservice(
+            claim1, custom_props={"service_id": service.id, "qty_provided": 2}
+        )
+        item1 = create_test_claimitem(
+            claim1, "A", custom_props={"item_id": item.id, "qty_provided": 3}
+        )
+        errors = validate_and_process_dedrem_claim(claim1, self.user, True)
+
+        self.assertEqual(len(errors), 0)
+        self.assertEqual(
+            claim1.status,
+            Claim.STATUS_PROCESSED,
+            "The claim has relative pricing, so should go to PROCESSED rather than VALUATED",
+        )
+        # Make sure that the dedrem was generated
+        dedrem = ClaimDedRem.objects.filter(claim=claim1).first()
+        self.assertIsNotNone(dedrem)
+        self.assertEquals(dedrem.rem_g, 500)  # 100*2 + 100*3
+
+        # When
+        do_process_batch(
+            self.user.id_for_audit,
+            None,
+            claim1.process_stamp.month,
+            claim1.process_stamp.year,
+        )
 
         claim1.refresh_from_db()
+        item1.refresh_from_db()
+        service1.refresh_from_db()
 
-        result = process_batch(1, location_id=1, period=6, year=2019)
+        self.assertEquals(claim1.status, Claim.STATUS_VALUATED)
 
         # tearDown
+        # dedrem.delete() # already done if the test passed
         premium.delete()
-        premium.payer.delete()
-        service1.delete()
-        claim1.delete()
+        payer.delete()
+        delete_claim_with_itemsvc_dedrem_and_history(claim1)
         policy.insuree_policies.first().delete()
         policy.delete()
+        product_item.delete()
         product_service.delete()
-        pricelist_detail.delete()
+        pricelist_detail1.delete()
+        pricelist_detail2.delete()
         service.delete()
-        for rd in product.relative_distributions.all():
-            rd.delete()
+        item.delete()
+        product.relativeindex_set.all().delete()
+        product.relative_distributions.all().delete()
         product.delete()


### PR DESCRIPTION
This commit starts with a big rewrite of the test of the procedure (it could use more test scenarios). It illustrated several issues:
* the procedure was looping on products and inserting data into a temp table. The loop was wrongly indented in the original stored procedure which led to a mistake in the Python version
* the relative pricing month is specified in relindex as "12" but in product as "M". One part of the procedure checked the wrong one and didn't raise an error when nothing matched.
* the care type was hard-coded as in-patient
* the remunerated_amount computation had a mistake
* the procedure uses a list of ids to switch to valuated. It is filled with the non-relative pricing claims but was in fact also used as a side-effect in the claim valuation. This is what caused the state not to change properly in all cases.