### PR TITLE
OP-1052: authenticate user from request

### DIFF
--- a/claim_batch/views.py
+++ b/claim_batch/views.py
@@ -1,4 +1,6 @@
 from django.core.exceptions import PermissionDenied
+
+from core.jwt_authentication import JWTAuthentication
 from report.services import ReportService
 from .services import ReportDataService
 from .reports import pbh, pbp, pbc_H, pbc_P
@@ -22,11 +24,12 @@ def _report(prms):
 
 
 def report(request):
-    if not request.user.has_perms(ClaimBatchConfig.account_preview_perms):
+    user = JWTAuthentication().authenticate(request)[0]
+    if not user.has_perms(ClaimBatchConfig.account_preview_perms):
         raise PermissionDenied(_("unauthorized"))
-    report_service = ReportService(request.user)
+    report_service = ReportService(user)
     report, default = _report(request.GET)
-    report_data_service = ReportDataService(request.user)
+    report_data_service = ReportDataService(user)
     data = report_data_service.fetch(request.GET)
     return report_service.process(report,
                                   {'data': data,


### PR DESCRIPTION
https://openimis.atlassian.net/browse/OP-1052

This PR fixes getting user from request when using REST endpoint that generates Batch Report.
Solution here might be different from expected based on ticket's description. Below is a comment I used under the ticket to explain why I chose to fix it on backend.

_Frontend logic seems to be fine. When user is deprived of right to PREVIEW, the Accounts panel is not visible. It is the request to generate the report that is a problem here and it returns 403 because on the backend the user in request is always anonymous._