### PR TITLE
Pandas 1.1 doesn't build on many systems

### DIFF
--- a/.github/workflows/openmis-module-test.yml
+++ b/.github/workflows/openmis-module-test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   run_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     services:
       mssql:
         image: mcr.microsoft.com/mssql/server:2017-latest

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'openimis-be-location',
         'openimis-be-product',
         'django-sql-utils',
-        'pandas==1.1.4',
+        'pandas~=1.4.2',
     ],
     classifiers=[
         'Environment :: Web Environment',


### PR DESCRIPTION
Even on recent Ubuntu LTS, 1.4 is a minimum to have a working build. We could even bump this further if necessary