### PR TITLE
refactor(test): update claim batch GraphQL test setup to use dynamic …

### DIFF
--- a/claim_batch/services.py
+++ b/claim_batch/services.py
@@ -367,28 +367,31 @@ def get_claim_queryset(product, status, batch_run, start_date, end_date):
     subquery = Claim.objects.filter(
         Q(items__product=product) | Q(services__product=product),
         Q(batch_run__isnull=True) | Q(batch_run=batch_run),
+        Q(Q(date_to__lt=end_date) | (Q(date_to__isnull=True) & Q(date_from__lt=end_date))),
+        *Claim.filter_validity(),
         status=status,
-        process_stamp__lt=datetime.datetime.now(),
-        validity_to__isnull=True
+        process_stamp__is_null=False,
     ).distinct().values('id')
     return Claim.objects.filter(id__in=Subquery(subquery))
     
 
 
 def get_allocated_contribution_queryset(product, start_date, end_date):
-    return Premium.objects \
-        .filter(policy__effective_date__lte=end_date) \
-        .filter(policy__expiry_date__gte=start_date) \
-        .filter(validity_to__isnull=True) \
-        .filter(policy__product=product) \
-        .select_related('policy')
+    return Premium.objects.filter(
+        *Claim.filter_validity(),
+        policy__effective_date__lte=end_date,
+        policy__expiry_date__gte=start_date,
+        policy__product=product
+        ).select_related('policy')
 
 
 def get_product_queryset(end_date, location_id):
-    queryset = Product.objects \
-        .filter(validity_to__isnull=True) \
-        .filter(date_from__lte=end_date) \
-        .filter(Q(date_to__gte=end_date) | Q(date_to__isnull=True))
+    queryset = Product.objects.filter(
+        Q(date_to__gte=end_date) | Q(date_to__isnull=True),
+        *Product.filter_validity(),
+       date_from__lte=end_date,
+        
+    )
     if location_id is not None:
         return queryset.filter(location_id=location_id)
     else:

--- a/claim_batch/services.py
+++ b/claim_batch/services.py
@@ -370,7 +370,7 @@ def get_claim_queryset(product, status, batch_run, start_date, end_date):
         Q(Q(date_to__lt=end_date) | (Q(date_to__isnull=True) & Q(date_from__lt=end_date))),
         *Claim.filter_validity(),
         status=status,
-        process_stamp__is_null=False,
+        process_stamp__isnull=False,
     ).distinct().values('id')
     return Claim.objects.filter(id__in=Subquery(subquery))
     

--- a/claim_batch/services.py
+++ b/claim_batch/services.py
@@ -368,7 +368,7 @@ def get_claim_queryset(product, status, batch_run, start_date, end_date):
         Q(items__product=product) | Q(services__product=product),
         Q(batch_run__isnull=True) | Q(batch_run=batch_run),
         status=status,
-        process_stamp__lte=end_date,
+        process_stamp__lt=datetime.datetime.now(),
         validity_to__isnull=True
     ).distinct().values('id')
     return Claim.objects.filter(id__in=Subquery(subquery))

--- a/claim_batch/tests/test_graphql.py
+++ b/claim_batch/tests/test_graphql.py
@@ -130,8 +130,8 @@ class ClaimBactchGQLTestCase(openIMISGraphQLTestCase):
             policy_id=policy.id, custom_props={"payer_id": payer.id}
         )
         claim1 = create_test_claim({"insuree_id": insuree.id})
-        pricelist_detail1 = add_service_to_hf_pricelist(service, claim1.health_facility_id)
-        pricelist_detail2 = add_item_to_hf_pricelist(item, claim1.health_facility_id)
+        pricelist_detail1 = add_service_to_hf_pricelist(service, claim1.health_facility)
+        pricelist_detail2 = add_item_to_hf_pricelist(item, claim1.health_facility)
         
         service1 = create_test_claimservice(
             claim1, custom_props={"service_id": service.id, "qty_provided": 2, "price_origin": ProductItemOrService.ORIGIN_RELATIVE}

--- a/claim_batch/tests/test_graphql.py
+++ b/claim_batch/tests/test_graphql.py
@@ -2,11 +2,11 @@ import json
 from dataclasses import dataclass
 from core.models import User
 from core.models.openimis_graphql_test_case import openIMISGraphQLTestCase, BaseTestContext
-from core.test_helpers import create_test_interactive_user
+from core.test_helpers import create_test_interactive_user, create_enrolment_officer_role
 from django.conf import settings
 from graphene_django.utils.testing import GraphQLTestCase
 from graphql_jwt.shortcuts import get_token
-from location.test_helpers import assign_user_districts
+from location.test_helpers import assign_user_districts, create_basic_test_locations
 from rest_framework import status
 from insuree.test_helpers import create_test_insuree
 from location.test_helpers import create_test_village
@@ -59,11 +59,12 @@ class ClaimBactchGQLTestCase(openIMISGraphQLTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        create_basic_test_locations()
         cls.test_village = create_test_village()
         cls.test_insuree = create_test_insuree(with_family=True, is_head=True, custom_props={'current_village':cls.test_village}, family_custom_props={'location':cls.test_village})
         cls.admin_user = create_test_interactive_user(username="testLocationAdmin")
         cls.admin_token = BaseTestContext(user=cls.admin_user).get_jwt()
-        cls.ca_user = create_test_interactive_user(username="testLocationNoRight", roles=[9])
+        cls.ca_user = create_test_interactive_user(username="testLocationNoRight", roles=[create_enrolment_officer_role().id])
         cls.ca_token = BaseTestContext(user=cls.ca_user).get_jwt()
         cls.admin_dist_user = create_test_interactive_user(username="testLocationDist")
         assign_user_districts(cls.admin_dist_user, ["R1D1", "R2D1", "R2D2", "R2D1", cls.test_village.parent.parent.code])


### PR DESCRIPTION
…role and location helpers

- Import and use create_enrolment_officer_role() for dynamic role assignment instead of hardcoded ID
- Add create_basic_test_locations() call in setUpClass for proper test environment initialization
- Improves test reliability by avoiding hardcoded values and ensuring consistent location setup