### PR TITLE
fix(test): pass HealthFacility object to pricelist helpers in ClaimBactchGQLTestCase

### DIFF
--- a/claim_batch/tests/test_graphql.py
+++ b/claim_batch/tests/test_graphql.py
@@ -129,8 +129,8 @@ class ClaimBactchGQLTestCase(openIMISGraphQLTestCase):
             policy_id=policy.id, custom_props={"payer_id": payer.id}
         )
         claim1 = create_test_claim({"insuree_id": insuree.id})
-        pricelist_detail1 = add_service_to_hf_pricelist(service, claim1.health_facility_id)
-        pricelist_detail2 = add_item_to_hf_pricelist(item, claim1.health_facility_id)
+        pricelist_detail1 = add_service_to_hf_pricelist(service, claim1.health_facility)
+        pricelist_detail2 = add_item_to_hf_pricelist(item, claim1.health_facility)
         
         service1 = create_test_claimservice(
             claim1, custom_props={"service_id": service.id, "qty_provided": 2, "price_origin": ProductItemOrService.ORIGIN_RELATIVE}


### PR DESCRIPTION
## Summary

- `add_service_to_hf_pricelist` and `add_item_to_hf_pricelist` expect an HF object — they access `hf.services_pricelist` / `hf.items_pricelist` directly.
- `claim_batch/tests/test_graphql.py` passes `claim1.health_facility_id` (an int), triggering `AttributeError: 'int' object has no attribute 'services_pricelist'` in `setUpClass`.
- Changed to `claim1.health_facility` so the helpers receive the correct type.

## Test plan

- [ ] `Run Module Tests` in CI goes green for ClaimBactchGQLTestCase
- [ ] Downstream jobs in openimis-be_py no longer show this class as failing